### PR TITLE
Upgrade Eve to 0.7.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ python_logstash_async==1.4.1
 Eve_Swagger==0.0.6
 flask_swagger_ui==0.0.2
 Flask_Zipkin==0.0.2
-Eve==0.6.4
+Eve==0.7.10
 Flask_Login==0.4.0
 pymongo==3.3.1
 Flask_PyMongo==0.5.2 # Not using newer v2.0.0 due to potentially breaking changes


### PR DESCRIPTION
Fixes issue in Work Order app when down step of `UpdateOldMaterialsStep` failed due to [bug in older version of Eve.](https://github.com/pyeve/eve/issues/920)